### PR TITLE
Remove the required Apache commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.binaryoverload</groupId>
     <artifactId>jsonconfig</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
 
     <dependencies>
         <dependency>
@@ -19,11 +19,6 @@
             <artifactId>junit</artifactId>
             <version>4.12</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>20030203.000550</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/github/binaryoverload/JSONConfig.java
+++ b/src/main/java/io/github/binaryoverload/JSONConfig.java
@@ -1,12 +1,9 @@
 package io.github.binaryoverload;
 
 import com.google.gson.*;
-import com.google.gson.stream.JsonReader;
-import org.apache.commons.io.IOUtil;
 
 import java.io.*;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * Main config class used to represent a json file
@@ -118,9 +115,8 @@ public class JSONConfig {
      *                      null, empty or any other lenth than 1</i>
      * @throws NullPointerException     if any of the passed arguments are null
      * @throws IllegalArgumentException if the path separator is empty or not a length of 1
-     * @throws IOException              if the stream is invalid or malformatted 
+     * @throws IOException              if the stream is invalid or malformatted
      * @see InputStream
-     * @see org.apache.commons.io.IOUtil
      * * @since 1.0
      */
     public JSONConfig(InputStream stream, String pathSeparator) throws IOException {
@@ -128,7 +124,8 @@ public class JSONConfig {
         Objects.requireNonNull(pathSeparator);
         GeneralUtils.checkStringLength(pathSeparator, 1);
         setPathSeparator(pathSeparator);
-        this.object = GSON.fromJson(IOUtil.toString(stream), JsonObject.class);
+        BufferedReader br = new BufferedReader(new InputStreamReader(stream));
+        this.object = GSON.fromJson(br.lines().collect(Collectors.joining("\n")), JsonObject.class);
         Objects.requireNonNull(this.getObject(), "Input is empty!");
     }
 

--- a/src/main/java/io/github/binaryoverload/JSONConfig.java
+++ b/src/main/java/io/github/binaryoverload/JSONConfig.java
@@ -1,9 +1,11 @@
 package io.github.binaryoverload;
 
 import com.google.gson.*;
+import com.google.gson.stream.JsonReader;
 
 import java.io.*;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Main config class used to represent a json file
@@ -126,6 +128,7 @@ public class JSONConfig {
         setPathSeparator(pathSeparator);
         BufferedReader br = new BufferedReader(new InputStreamReader(stream));
         this.object = GSON.fromJson(br.lines().collect(Collectors.joining("\n")), JsonObject.class);
+        br.close();
         Objects.requireNonNull(this.getObject(), "Input is empty!");
     }
 

--- a/src/main/java/io/github/binaryoverload/JSONConfig.java
+++ b/src/main/java/io/github/binaryoverload/JSONConfig.java
@@ -127,7 +127,7 @@ public class JSONConfig {
         GeneralUtils.checkStringLength(pathSeparator, 1);
         setPathSeparator(pathSeparator);
         BufferedReader br = new BufferedReader(new InputStreamReader(stream));
-        this.object = GSON.fromJson(br.lines().collect(Collectors.joining("\n")), JsonObject.class);
+        this.object = GSON.fromJson(br.lines().collect(Collectors.joining()), JsonObject.class);
         br.close();
         Objects.requireNonNull(this.getObject(), "Input is empty!");
     }


### PR DESCRIPTION
This can be achieved in vanilla Java just as easily. Instead of using IOUtil#toString just use a BufferedReader#lines and collect them with a new line. This allows for just GSON and Java without also having to depend on Apache commons for 1 simple line of code.